### PR TITLE
chore: throw if duplicate detected when importing

### DIFF
--- a/scripts/import.js
+++ b/scripts/import.js
@@ -169,6 +169,9 @@ async function fetchImageUrls(icons, figmaToken) {
   return json;
 }
 
+// This detects duplicate icons (e.g. two icons named the same thing in Figma)
+const seen = []
+
 /**
  * Get the SVG icon
  */
@@ -178,6 +181,9 @@ async function downloadSvgIcon({ iconName, url }) {
 
   // the icon name has the size of the icon included, which we don't want
   const { size, name } = sizeAndName(iconName);
+  const token = `${size}${name}`
+  if (seen.includes(token)) throw `--- DUPLICATE ICON DETECTED ${token}. Multiple icons are likely named ${name} and would override each other. This must be fixed in Figma. ---`
+  seen.push(token)
 
   // this avoids downloading misnamed icons with no name
   // technically this makes the 'count' be off up above, but meh


### PR DESCRIPTION
Changes based on a similar fix in fabric-ds/icons: https://github.com/fabric-ds/icons/pull/35

We don't have any duplicate names at the moment but should this ever be a problem in the future, we'd be able to spot it already at the importing stage.