### PR TITLE
chore(.releaserc.json): disable release success comments in related PRs

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,7 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
       ["@semantic-release/npm", { "tarballDir": "release" }],
-      ["@semantic-release/github", { "assets": "release/*.tgz" }],
+      ["@semantic-release/github", { "assets": "release/*.tgz", "successComment" : false }],
       "@semantic-release/git"
     ]
   }


### PR DESCRIPTION
We agreed in other Warp packages to not have success comments for each PR that is included in a release. This PR disables that option here, too.