### PR TITLE
fix: set next as default prerelease branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - alpha
       - beta
       - next
 jobs:

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -1,10 +1,10 @@
-name: Update alpha
+name: Update next
 on:
   workflow_run:
     workflows:
       - Release
     branches:
-      - alpha
+      - main
     types: completed
 jobs:
   rebase:
@@ -12,9 +12,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Rebase alpha to main
+      - name: Rebase next to main
         run: |
           git fetch --unshallow
-          git checkout alpha
+          git checkout next
           git rebase origin/main
           git push

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,6 @@
 {
     "branches": [
         { "name": "main" },
-        { "name": "alpha", "prerelease": true },
         { "name": "beta", "prerelease": true },
         { "name": "next", "prerelease": true }
     ], 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ pnpm dev
 
 ## Releases
 
-This project is continuously published to [NPM](https://www.npmjs.com/package/@warp-ds/icons) and [Eik](https://assets.finn.no/pkg/@warp-ds/icons) using an `alpha` tag (e.g. `1.1.0-alpha.1`).
-Anyone needing to use the latest changes of this package can point to the `alpha` version while waiting for the stable release.
+This project is continuously published to [NPM](https://www.npmjs.com/package/@warp-ds/icons) and [Eik](https://assets.finn.no/pkg/@warp-ds/icons) using a `next` tag (e.g. `1.1.0-next.1`).
+Anyone needing to use the latest changes of this package can point to the `next` version while waiting for the stable release.
 
 Eik versions for each of Vue, Elements and React icons that are built to the ./dist folder are automatically published to Eik under the path `https://assets.finn.no/pkg/{name}/{version}/`.
 


### PR DESCRIPTION
This will align with how we continue development of @warp-ds packages after the main 1.0.0 release is out.

Note: this PR should create a 1.0.0-next.1 tag, but will not publish assets to NPM and Eik. This is because that version was already released by accident upon creation of the `next` branch in this repo. Although the tag was removed and git history was fixed, the version on NPM and Eik stayed unchanged. In order to update the assets there, we need to trigger a new release by opening a new "fix" PR.