### PR TITLE
feat: Handle i18n for vue

### DIFF
--- a/scripts/output/vue.js
+++ b/scripts/output/vue.js
@@ -23,9 +23,9 @@ getSVGs().forEach(({ svg, filename, exportName, name }) => {
     `import { messages as enMessages} from '../src/raw/${name}/locales/en/messages.mjs';`,
     `import { messages as fiMessages} from '../src/raw/${name}/locales/fi/messages.mjs';`,
     `import { activateI18n } from '../src/utils/i18n';`,
+    `import { h } from 'vue'`,
     `activateI18n(enMessages, nbMessages, fiMessages);`,
     `const title = i18n.t({ message: \`${message}\`, id: '${id}', comment: '${comment}' });`,
-    `import { h } from 'vue'`,
     `export default (_, { attrs }) => h('svg', { ${attrs.join(', ')}, innerHTML: ${'`'}${titleHtml}${svg.html}${'`'}, ...attrs })`
   ].join('\n')
   const path = joinPath(basepath, filename)

--- a/scripts/output/vue.js
+++ b/scripts/output/vue.js
@@ -2,17 +2,31 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { join as joinPath } from 'node:path'
 import { getSVGs, getDirname } from '../util/helpers.js'
 import chalk from 'chalk'
+import defaultIconDescriptions from '../../default-icon-descriptions.js'
 
 const __dirname = getDirname(import.meta.url)
 const icons = []
 const basepath = joinPath(__dirname, '../../vue/')
 mkdirSync(basepath, { recursive: true })
 
-getSVGs().forEach(({ svg, filename, exportName }) => {
+// Create Vue Icon
+getSVGs().forEach(({ svg, filename, exportName, name }) => {
+    // Handle i18n of icon title
+    const iconNameCamelCase = exportName.replace('Icon', '').replace(/\d+/g, '');
+    const titleMessage = defaultIconDescriptions[iconNameCamelCase.toLowerCase()];
   const attrs = Array.from(svg.attrs).map(attr => attr.name + `: ` + `'` + attr.value + `'`)
+  const { message, id, comment } = titleMessage || {};
+  const titleHtml = "<title>${title}</title>";
   const output = [
+    `import { i18n } from '@lingui/core';`,
+    `import { messages as nbMessages} from '../src/raw/${name}/locales/nb/messages.mjs';`,
+    `import { messages as enMessages} from '../src/raw/${name}/locales/en/messages.mjs';`,
+    `import { messages as fiMessages} from '../src/raw/${name}/locales/fi/messages.mjs';`,
+    `import { activateI18n } from '../src/utils/i18n';`,
+    `activateI18n(enMessages, nbMessages, fiMessages);`,
+    `const title = i18n.t({ message: \`${message}\`, id: '${id}', comment: '${comment}' });`,
     `import { h } from 'vue'`,
-    `export default (_, { attrs }) => h('svg', { ${attrs.join(', ')}, innerHTML: '${svg.html}', ...attrs })`
+    `export default (_, { attrs }) => h('svg', { ${attrs.join(', ')}, innerHTML: ${'`'}${titleHtml}${svg.html}${'`'}, ...attrs })`
   ].join('\n')
   const path = joinPath(basepath, filename)
   writeFileSync(path, output, 'utf-8')

--- a/scripts/output/vue.js
+++ b/scripts/output/vue.js
@@ -11,12 +11,12 @@ mkdirSync(basepath, { recursive: true })
 
 // Create Vue Icon
 getSVGs().forEach(({ svg, filename, exportName, name }) => {
-    // Handle i18n of icon title
-    const iconNameCamelCase = exportName.replace('Icon', '').replace(/\d+/g, '');
-    const titleMessage = defaultIconDescriptions[iconNameCamelCase.toLowerCase()];
+  const iconNameCamelCase = exportName.replace(/Icon|\d+/g, '');
+  const titleMessage = defaultIconDescriptions[iconNameCamelCase.toLowerCase()];
   const attrs = Array.from(svg.attrs).map(attr => attr.name + `: ` + `'` + attr.value + `'`)
   const { message, id, comment } = titleMessage || {};
   const titleHtml = "<title>${title}</title>";
+  // Handle i18n of icon title
   const output = [
     `import { i18n } from '@lingui/core';`,
     `import { messages as nbMessages} from '../src/raw/${name}/locales/nb/messages.mjs';`,


### PR DESCRIPTION
Refactor script for generating vue icons to also handle i18n + add translated title for Vue icons (found in scripts/output/vue.js)

**To test:** 
1. Run `pnpm build:vue` in this branch
2. Try to change the message in a messages.mjs-file in one of the icons-folders found under /src/raw (example: /src/raw/info/locales/fi/messages.mjs)
<img width="1506" alt="Skärmavbild 2023-09-26 kl  15 42 05" src="https://github.com/warp-ds/icons/assets/144792260/5c98e1ec-d12a-4107-a0be-624af25a73e7">

4. Link this branch to an existing Vue-project that has @warp-ds/icon installed as a devDependency and run `pnpm build`
5. Use the icon with the altered message in the existing Vue-project and run the project, example: `<icon-info16 />`
<img width="683" alt="Skärmavbild 2023-09-26 kl  15 44 18" src="https://github.com/warp-ds/icons/assets/144792260/81f9012d-5dd3-43e9-a35b-eebd33784c1a">


7. Inspect the icon in the browser and see if your altered message is there
<img width="1263" alt="Skärmavbild 2023-09-26 kl  15 43 13" src="https://github.com/warp-ds/icons/assets/144792260/148207a5-d3c5-46b2-94dd-ae77664c42b6">


