### PR TITLE
feat:Handle i18n for elements

### DIFF
--- a/scripts/output/elements.js
+++ b/scripts/output/elements.js
@@ -36,7 +36,7 @@ getSVGs().forEach(({ svg, name, size, filename, exportName }) => {
       
       return html\`<svg ${attrs.join("")}>${titleHtml}${svg.html}</svg>\`; }`,
     `}`,
-    `if (!customElements.get('w-icon-${name}${size}')) {`,
+    `if (!customElements.get('w-icon-${name}${size}', ${className})) {`,
     `  customElements.define('w-icon-${name}${size}', ${className});`,
     `}`,
   ].join("\n");

--- a/scripts/output/elements.js
+++ b/scripts/output/elements.js
@@ -21,7 +21,7 @@ getSVGs().forEach(({ svg, name, size, filename, exportName }) => {
   const className = exportName;
   // Handle i18n for icon title
   const output = [
-    `import { LitElement, html, svg } from 'lit';`,
+    `import { LitElement, html } from 'lit';`,
     `import { i18n } from '@lingui/core';`,
     `import { messages as nbMessages} from '../src/raw/${name}/locales/nb/messages.mjs';`,
     `import { messages as enMessages} from '../src/raw/${name}/locales/en/messages.mjs';`,

--- a/scripts/output/elements.js
+++ b/scripts/output/elements.js
@@ -1,21 +1,38 @@
-import { mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join as joinPath } from 'node:path'
 import { getSVGs, getDirname } from '../util/helpers.js'
 import chalk from 'chalk'
+import defaultIconDescriptions from '../../default-icon-descriptions.js'
 
 const __dirname = getDirname(import.meta.url)
 const icons = []
 const basepath = joinPath(__dirname, '../../elements/')
 mkdirSync(basepath, { recursive: true })
 
+// Create Elements Icon
 getSVGs().forEach(({ svg, name, size, filename, exportName }) => {
+  const iconNameCamelCase = exportName.replace(/Icon|\d+/g, '');
+  const titleMessage = defaultIconDescriptions[iconNameCamelCase.toLowerCase()];
   const attrs = Array.from(svg.attrs).map(attr => attr.name + `=` + `"` + attr.value + `"`)
+  const { message, id, comment } = titleMessage || {};
+  const titleHtml = "<title>${title}</title>";
   const className = exportName
+  // Handle i18n for icon title
   const output = [
     `import { LitElement, html, svg } from 'lit';`,
+    `import { i18n } from '@lingui/core';`,
+    `import { messages as nbMessages} from '../../src/raw/${name}/locales/nb/messages.mjs';`,
+    `import { messages as enMessages} from '../../src/raw/${name}/locales/en/messages.mjs';`,
+    `import { messages as fiMessages} from '../../src/raw/${name}/locales/fi/messages.mjs';`,
+    `import { activateI18n } from '../../src/utils/i18n';`,
+    `activateI18n(enMessages, nbMessages, fiMessages);`,
+    ``,
     ``,
     `export class ${className} extends LitElement {`,
-    `  render() { return html\`<svg ${attrs.join(' ')}>${svg.html}</svg>\`; }`,
+    `  render() {
+      const title = i18n.t({ message: \`${message}\`, id: '${id}', comment: '${comment}' });
+      
+      return html\`<svg ${attrs.join('')}>${titleHtml}${svg.html}</svg>\`; }`,
     `}`,
     `if (!customElements.get('w-icon-${name}${size}', ${className})) {`,
     `  customElements.define('w-icon-${name}${size}', ${className});`,
@@ -23,13 +40,21 @@ getSVGs().forEach(({ svg, name, size, filename, exportName }) => {
   ].join("\n");
 
 
-  const path = joinPath(basepath, filename)
-  writeFileSync(path, output, 'utf-8')
-  icons.push({ exportName, filename })
-})
-console.log(`${chalk.blue('lit')}: Wrote ${chalk.yellow(icons.length)} icon files`)
+  // Make subfolder for each icon name if it doesn't exist
+  const iconNamePath = `${basepath}${name}/`;
+  !existsSync(iconNamePath) && mkdirSync(iconNamePath, { recursive: true })
 
-const indexFile = icons.map(({ filename }) => `export * from './${filename}';`).join("\n");
+  const path = joinPath(iconNamePath, filename)
+  writeFileSync(path, output, 'utf-8')
+  icons.push({ exportName, filename, name })
+})
+
+const iconNames = Array.from(new Set(icons.map(icon => icon.name)));
+console.log(`${chalk.cyan('react')}: Processing ${chalk.yellow(iconNames.length)} icons`)
+console.log(`${chalk.cyan('react')}: Wrote ${chalk.yellow(icons.length)} icon files (different sizes for the same icon)`)
+
+// Create index file
+const indexFile = icons.map(({ filename, name }) => `export * from './${name}/${filename}'`) .join("\n");
 const indexFilename = joinPath(basepath, 'index.js')
-writeFileSync(indexFilename, indexFile, 'utf-8')
-console.log(`${chalk.blue('lit')}: Wrote ${chalk.yellow('index')} file`)
+writeFileSync(indexFilename, `${indexFile}`, 'utf-8')
+console.log(`${chalk.cyan('react')}: Wrote ${chalk.yellow('index')} file`)

--- a/scripts/output/elements.js
+++ b/scripts/output/elements.js
@@ -1,30 +1,32 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
-import { join as joinPath } from 'node:path'
-import { getSVGs, getDirname } from '../util/helpers.js'
-import chalk from 'chalk'
-import defaultIconDescriptions from '../../default-icon-descriptions.js'
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join as joinPath } from "node:path";
+import { getSVGs, getDirname } from "../util/helpers.js";
+import chalk from "chalk";
+import defaultIconDescriptions from "../../default-icon-descriptions.js";
 
-const __dirname = getDirname(import.meta.url)
-const icons = []
-const basepath = joinPath(__dirname, '../../elements/')
-mkdirSync(basepath, { recursive: true })
+const __dirname = getDirname(import.meta.url);
+const icons = [];
+const basepath = joinPath(__dirname, "../../elements/");
+mkdirSync(basepath, { recursive: true });
 
 // Create Elements Icon
 getSVGs().forEach(({ svg, name, size, filename, exportName }) => {
-  const iconNameCamelCase = exportName.replace(/Icon|\d+/g, '');
+  const iconNameCamelCase = exportName.replace(/Icon|\d+/g, "");
   const titleMessage = defaultIconDescriptions[iconNameCamelCase.toLowerCase()];
-  const attrs = Array.from(svg.attrs).map(attr => attr.name + `=` + `"` + attr.value + `"`)
+  const attrs = Array.from(svg.attrs).map(
+    (attr) => attr.name + `=` + `"` + attr.value + `"`
+  );
   const { message, id, comment } = titleMessage || {};
   const titleHtml = "<title>${title}</title>";
-  const className = exportName
+  const className = exportName;
   // Handle i18n for icon title
   const output = [
     `import { LitElement, html, svg } from 'lit';`,
     `import { i18n } from '@lingui/core';`,
-    `import { messages as nbMessages} from '../../src/raw/${name}/locales/nb/messages.mjs';`,
-    `import { messages as enMessages} from '../../src/raw/${name}/locales/en/messages.mjs';`,
-    `import { messages as fiMessages} from '../../src/raw/${name}/locales/fi/messages.mjs';`,
-    `import { activateI18n } from '../../src/utils/i18n';`,
+    `import { messages as nbMessages} from '../src/raw/${name}/locales/nb/messages.mjs';`,
+    `import { messages as enMessages} from '../src/raw/${name}/locales/en/messages.mjs';`,
+    `import { messages as fiMessages} from '../src/raw/${name}/locales/fi/messages.mjs';`,
+    `import { activateI18n } from '../src/utils/i18n';`,
     `activateI18n(enMessages, nbMessages, fiMessages);`,
     ``,
     ``,
@@ -32,29 +34,25 @@ getSVGs().forEach(({ svg, name, size, filename, exportName }) => {
     `  render() {
       const title = i18n.t({ message: \`${message}\`, id: '${id}', comment: '${comment}' });
       
-      return html\`<svg ${attrs.join('')}>${titleHtml}${svg.html}</svg>\`; }`,
+      return html\`<svg ${attrs.join("")}>${titleHtml}${svg.html}</svg>\`; }`,
     `}`,
-    `if (!customElements.get('w-icon-${name}${size}', ${className})) {`,
+    `if (!customElements.get('w-icon-${name}${size}')) {`,
     `  customElements.define('w-icon-${name}${size}', ${className});`,
     `}`,
   ].join("\n");
 
+  const path = joinPath(basepath, filename);
+  writeFileSync(path, output, "utf-8");
+  icons.push({ exportName, filename });
+});
+console.log(
+  `${chalk.blue("lit")}: Wrote ${chalk.yellow(icons.length)} icon files`
+);
 
-  // Make subfolder for each icon name if it doesn't exist
-  const iconNamePath = `${basepath}${name}/`;
-  !existsSync(iconNamePath) && mkdirSync(iconNamePath, { recursive: true })
+const indexFile = icons
+  .map(({ filename }) => `export * from './${filename}';`)
+  .join("\n");
+const indexFilename = joinPath(basepath, "index.js");
+writeFileSync(indexFilename, indexFile, "utf-8");
+console.log(`${chalk.blue("lit")}: Wrote ${chalk.yellow("index")} file`);
 
-  const path = joinPath(iconNamePath, filename)
-  writeFileSync(path, output, 'utf-8')
-  icons.push({ exportName, filename, name })
-})
-
-const iconNames = Array.from(new Set(icons.map(icon => icon.name)));
-console.log(`${chalk.cyan('react')}: Processing ${chalk.yellow(iconNames.length)} icons`)
-console.log(`${chalk.cyan('react')}: Wrote ${chalk.yellow(icons.length)} icon files (different sizes for the same icon)`)
-
-// Create index file
-const indexFile = icons.map(({ filename, name }) => `export * from './${name}/${filename}'`) .join("\n");
-const indexFilename = joinPath(basepath, 'index.js')
-writeFileSync(indexFilename, `${indexFile}`, 'utf-8')
-console.log(`${chalk.cyan('react')}: Wrote ${chalk.yellow('index')} file`)


### PR DESCRIPTION
Refactor script for generating elements icons to also handle i18n + add translated title for elements icons (found in scripts/output/elements.js)

**To test:** 
1. Run `pnpm build:elements` in this branch
2. Try to change the message in a messages.mjs-file in one of the icons-folders found under /src/raw (example: /src/raw/chevron-down/locales/fi/messages.mjs)


4. Link this branch to an existing elements-project that has @warp-ds/icon installed as a devDependency and run `pnpm build`

5. Use the icon with the altered message in the existing elements-project.* Then run the project, example: `<w-icon-chevron-down16></w-icon-chevron-down16>`

7. Inspect the icon in the browser and see if your altered message is there

*Note: Make sure to change the language in the html to the same language where you altered the message in the messages.mjs-file (example: if you changed messages.mjs under the /fi folder, then the language for the html needs to be changed to "fi").

