### PR TITLE
fix: element icons names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import { IconChevronRight16 } from '@warp-ds/icons/vue';
 ```
 
 ```js
-<icon-chevron-right16 />
+<icon-chevron-right-16 />
 ```
 
 ### Elements
@@ -62,8 +62,8 @@ import '@warp-ds/icons/elements/attachment-24';
 ```
 
 ```html
-<w-icon-attachment16></w-icon-attachment16>
-<w-icon-attachment24></w-icon-attachment24>
+<w-icon-attachment-16></w-icon-attachment-16>
+<w-icon-attachment-24></w-icon-attachment-24>
 ```
 
 

--- a/scripts/output/elements.js
+++ b/scripts/output/elements.js
@@ -17,8 +17,8 @@ getSVGs().forEach(({ svg, name, size, filename, exportName }) => {
     `export class ${className} extends LitElement {`,
     `  render() { return html\`<svg ${attrs.join(' ')}>${svg.html}</svg>\`; }`,
     `}`,
-    `if (!customElements.get('w-icon-${name}${size}', ${className})) {`,
-    `  customElements.define('w-icon-${name}${size}', ${className});`,
+    `if (!customElements.get('w-icon-${name}-${size}', ${className})) {`,
+    `  customElements.define('w-icon-${name}-${size}', ${className});`,
     `}`,
   ].join("\n");
 


### PR DESCRIPTION
This PR ensures icon element names have a consistent kebab-case. Although it's technically a breaking change, we have not seen any NMP teams use Warp icon elements just yet, so it should be fine to release it as a fix so early in the development.