### PR TITLE
fix: add 9BA8BA to exchange with currentColor

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -17,7 +17,7 @@ const SRC_DIR = path.join(basedir, "src/raw");
 const DIST_DIR = path.join(basedir, "dist");
 
 // these are the only colors we will replace to currentColor
-const magicColors = ['#71717a', '#767676', '#0063fb', '#d91f0a', '#d5840b', '#059e6f', '#0386bf', '#6f7d90'].map(v => v.toLowerCase())
+const magicColors = ['#9BA8BA', '#71717a', '#767676', '#0063fb', '#d91f0a', '#d5840b', '#059e6f', '#0386bf', '#6f7d90'].map(v => v.toLowerCase())
 const colorProps = [
   'color',
   'fill',


### PR DESCRIPTION
We have discovered that we have a new color that should be added to the `magicColors` array to be exchanged with `currentColor`.
@Skadefryd had a great point about the way we are adding the icons to Figma. We should only use one color `#717171a` or any other "green screen" color that would be used for coloration. And then it will be easy to exchange this color in build.js when we optimize our icons and we can get rid of the `magicColors` array and only use one string. 