### PR TITLE
fix: add more missing titles

### DIFF
--- a/src/raw/active-ads/locales/en/messages.po
+++ b/src/raw/active-ads/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/active-ads.js:2
 msgid "icon.title.active-ads"
 msgstr "Sheet with image and headline with highlighted checkmark"
-

--- a/src/raw/ads/locales/en/messages.po
+++ b/src/raw/ads/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/ads.js:2
 msgid "icon.title.ads"
 msgstr "Sheet with image and headline"
-

--- a/src/raw/air-con/locales/en/messages.po
+++ b/src/raw/air-con/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/air-con.js:2
 msgid "icon.title.air-con"
 msgstr "Small air cooler"
-

--- a/src/raw/airplane-hotel/locales/en/messages.po
+++ b/src/raw/airplane-hotel/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/airplane-hotel.js:2
 msgid "icon.title.airplane-hotel"
 msgstr "Flight and hotel"
-

--- a/src/raw/airplane/locales/en/messages.po
+++ b/src/raw/airplane/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/airplane.js:2
 msgid "icon.title.airplane"
 msgstr "Airplane"
-

--- a/src/raw/alert-error/locales/en/messages.po
+++ b/src/raw/alert-error/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/alert-error.js:2
 msgid "icon.title.alert-error"
 msgstr "Red octagon with white exclamation point"
-

--- a/src/raw/alert-info/locales/en/messages.po
+++ b/src/raw/alert-info/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/alert-info.js:2
 msgid "icon.title.alert-info"
 msgstr "Blue circle with the letter I"
-

--- a/src/raw/alert-success/locales/en/messages.po
+++ b/src/raw/alert-success/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/alert-success.js:2
 msgid "icon.title.alert-success"
 msgstr "Green circle with checkmark"
-

--- a/src/raw/alert-warning/locales/en/messages.po
+++ b/src/raw/alert-warning/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/alert-warning.js:2
 msgid "icon.title.alert-warning"
 msgstr "Yellow warning triangle with exclamation point"
-

--- a/src/raw/alert/locales/en/messages.po
+++ b/src/raw/alert/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/alert.js:2
 msgid "icon.title.alert"
 msgstr "Circle with exclamation point"
-

--- a/src/raw/all-wheel-drive/locales/en/messages.po
+++ b/src/raw/all-wheel-drive/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/all-wheel-drive.js:2
 msgid "icon.title.all-wheel-drive"
 msgstr "All-wheel drive"
-

--- a/src/raw/archway/locales/en/messages.po
+++ b/src/raw/archway/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/archway.js:2
 msgid "icon.title.archway"
 msgstr "Archway"
-

--- a/src/raw/attachment/locales/en/messages.po
+++ b/src/raw/attachment/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/attachment.js:2
 msgid "icon.title.attachment"
 msgstr "Paperclip"
-

--- a/src/raw/automatic/locales/en/messages.po
+++ b/src/raw/automatic/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/automatic.js:2
 msgid "icon.title.automatic"
 msgstr "Automatic transmission"
-

--- a/src/raw/back-wheel-drive/locales/en/messages.po
+++ b/src/raw/back-wheel-drive/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/back-wheel-drive.js:2
 msgid "icon.title.back-wheel-drive"
 msgstr "Rear-wheel drive"
-

--- a/src/raw/bag/locales/en/messages.po
+++ b/src/raw/bag/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/bag.js:2
 msgid "icon.title.bag"
 msgstr "Handbag"
-

--- a/src/raw/bank-id/locales/en/messages.po
+++ b/src/raw/bank-id/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/bank-id.js:2
 msgid "icon.title.bank-id"
 msgstr "BankID logo"
-

--- a/src/raw/bank-ident/locales/en/messages.po
+++ b/src/raw/bank-ident/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/bank-ident.js:2
 msgid "icon.title.bank-ident"
 msgstr "Shield with checkmark"
-

--- a/src/raw/bank/locales/en/messages.po
+++ b/src/raw/bank/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/bank.js:2
 msgid "icon.title.bank"
 msgstr "A bank with three columns"
-

--- a/src/raw/battery-empty/locales/en/messages.po
+++ b/src/raw/battery-empty/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/battery-empty.js:2
 msgid "icon.title.battery-empty"
 msgstr "Empty battery"
-

--- a/src/raw/battery-full/locales/en/messages.po
+++ b/src/raw/battery-full/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/battery-full.js:2
 msgid "icon.title.battery-full"
 msgstr "Full battery"
-

--- a/src/raw/battery-half-full/locales/en/messages.po
+++ b/src/raw/battery-half-full/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/battery-half-full.js:2
 msgid "icon.title.battery-half-full"
 msgstr "Half-full battery"
-

--- a/src/raw/beach/locales/en/messages.po
+++ b/src/raw/beach/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/beach.js:2
 msgid "icon.title.beach"
 msgstr "Beach umbrella"
-

--- a/src/raw/bell/locales/en/messages.po
+++ b/src/raw/bell/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/bell.js:2
 msgid "icon.title.bell"
 msgstr "Bell"
-

--- a/src/raw/bin/locales/en/messages.po
+++ b/src/raw/bin/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/bin.js:2
 msgid "icon.title.bin"
 msgstr "Trash can"
-

--- a/src/raw/block/locales/en/messages.po
+++ b/src/raw/block/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/block.js:2
 msgid "icon.title.block"
 msgstr "Person with highlighted no entry sign"
-

--- a/src/raw/boat-length/locales/en/messages.po
+++ b/src/raw/boat-length/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/boat-length.js:2
 msgid "icon.title.boat-length"
 msgstr "Boat with arrows in both directions"
-

--- a/src/raw/bolt/locales/en/messages.po
+++ b/src/raw/bolt/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/bolt.js:2
 msgid "icon.title.bolt"
 msgstr "Lightning bolt"
-

--- a/src/raw/bookmark/locales/en/messages.po
+++ b/src/raw/bookmark/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/bookmark.js:2
 msgid "icon.title.bookmark"
 msgstr "Bookmark"
-

--- a/src/raw/building-plot/locales/en/messages.po
+++ b/src/raw/building-plot/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/building-plot.js:2
 msgid "icon.title.building-plot"
 msgstr "Dotted square with a highlighted house"
-

--- a/src/raw/building/locales/en/messages.po
+++ b/src/raw/building/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/building.js:2
 msgid "icon.title.building"
 msgstr "Apartment building"
-

--- a/src/raw/bulb/locales/en/messages.po
+++ b/src/raw/bulb/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/bulb.js:2
 msgid "icon.title.bulb"
 msgstr "Lightbulb"
-

--- a/src/raw/bulldozer/locales/en/messages.po
+++ b/src/raw/bulldozer/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/bulldozer.js:2
 msgid "icon.title.bulldozer"
 msgstr "Bulldozer"
-

--- a/src/raw/burger/locales/en/messages.po
+++ b/src/raw/burger/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/burger.js:2
 msgid "icon.title.burger"
 msgstr "Three horizontal lines"
-

--- a/src/raw/bus/locales/en/messages.po
+++ b/src/raw/bus/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/bus.js:2
 msgid "icon.title.bus"
 msgstr "Bus"
-

--- a/src/raw/cabin-hut/locales/en/messages.po
+++ b/src/raw/cabin-hut/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/cabin-hut.js:2
 msgid "icon.title.cabin-hut"
 msgstr "Cabin with garden"
-

--- a/src/raw/cabin/locales/en/messages.po
+++ b/src/raw/cabin/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/cabin.js:2
 msgid "icon.title.cabin"
 msgstr "Vacation cabin"
-

--- a/src/raw/calculator/locales/en/messages.po
+++ b/src/raw/calculator/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/calculator.js:2
 msgid "icon.title.calculator"
 msgstr "Calculator"
-

--- a/src/raw/calendar/locales/en/messages.po
+++ b/src/raw/calendar/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/calendar.js:2
 msgid "icon.title.calendar"
 msgstr "Calendar"
-

--- a/src/raw/camera/locales/en/messages.po
+++ b/src/raw/camera/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/camera.js:2
 msgid "icon.title.camera"
 msgstr "Camera"
-

--- a/src/raw/camping/locales/en/messages.po
+++ b/src/raw/camping/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/camping.js:2
 msgid "icon.title.camping"
 msgstr "Camper"
-

--- a/src/raw/car-key/locales/en/messages.po
+++ b/src/raw/car-key/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/car-key.js:2
 msgid "icon.title.car-key"
 msgstr "Car key"
-

--- a/src/raw/car-rent/locales/en/messages.po
+++ b/src/raw/car-rent/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/car-rent.js:2
 msgid "icon.title.car-rent"
 msgstr "Car and clock"
-

--- a/src/raw/car-service/locales/en/messages.po
+++ b/src/raw/car-service/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/car-service.js:2
 msgid "icon.title.car-service"
 msgstr "Car and star"
-

--- a/src/raw/car-subscription/locales/en/messages.po
+++ b/src/raw/car-subscription/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/car-subscription.js:2
 msgid "icon.title.car-subscription"
 msgstr "Car and checklist"
-

--- a/src/raw/car/locales/en/messages.po
+++ b/src/raw/car/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/car.js:2
 msgid "icon.title.car"
 msgstr "Car"
-

--- a/src/raw/cart/locales/en/messages.po
+++ b/src/raw/cart/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/cart.js:2
 msgid "icon.title.cart"
 msgstr "Shopping cart"
-

--- a/src/raw/chainsaw/locales/en/messages.po
+++ b/src/raw/chainsaw/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/chainsaw.js:2
 msgid "icon.title.chainsaw"
 msgstr "Chainsaw"
-

--- a/src/raw/charger/locales/en/messages.po
+++ b/src/raw/charger/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/charger.js:2
 msgid "icon.title.charger"
 msgstr "Charging cable"
-

--- a/src/raw/charter/locales/en/messages.po
+++ b/src/raw/charter/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/charter.js:2
 msgid "icon.title.charter"
 msgstr "Suitcase"
-

--- a/src/raw/chat-request/locales/en/messages.po
+++ b/src/raw/chat-request/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/chat-request.js:2
 msgid "icon.title.chat-request"
 msgstr "Speech bubble next to a person"
-

--- a/src/raw/chat-support/locales/en/messages.po
+++ b/src/raw/chat-support/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/chat-support.js:2
 msgid "icon.title.chat-support"
 msgstr "Speech bubbles with smiley faces"
-

--- a/src/raw/check/locales/en/messages.po
+++ b/src/raw/check/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/check.js:2
 msgid "icon.title.check"
 msgstr "Checkmark"
-

--- a/src/raw/checklist/locales/en/messages.po
+++ b/src/raw/checklist/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/checklist.js:2
 msgid "icon.title.checklist"
 msgstr "Checklist"
-

--- a/src/raw/chevron-double-left/locales/en/messages.po
+++ b/src/raw/chevron-double-left/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/chevron-double-left.js:2
 msgid "icon.title.chevron-double-left"
 msgstr "Double leftward arrow"
-

--- a/src/raw/chevron-double-left/locales/nb/messages.po
+++ b/src/raw/chevron-double-left/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/chevron-double-left.js:2
 msgid "icon.title.chevron-double-left"
-msgstr ""
+msgstr "Dobbel pil venstre"

--- a/src/raw/chevron-double-right/locales/en/messages.po
+++ b/src/raw/chevron-double-right/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/chevron-double-right.js:2
 msgid "icon.title.chevron-double-right"
 msgstr "Double rightward arrow"
-

--- a/src/raw/chevron-double-right/locales/nb/messages.po
+++ b/src/raw/chevron-double-right/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/chevron-double-right.js:2
 msgid "icon.title.chevron-double-right"
-msgstr ""
+msgstr "Dobbel pil høyre"

--- a/src/raw/chevron-down/locales/en/messages.po
+++ b/src/raw/chevron-down/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/chevron-down.js:2
 msgid "icon.title.chevron-down"
 msgstr "Downward arrow"
-

--- a/src/raw/chevron-down/locales/nb/messages.po
+++ b/src/raw/chevron-down/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/chevron-down.js:2
 msgid "icon.title.chevron-down"
-msgstr ""
+msgstr "Pil ned"

--- a/src/raw/chevron-left/locales/en/messages.po
+++ b/src/raw/chevron-left/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/chevron-left.js:2
 msgid "icon.title.chevron-left"
 msgstr "Leftward arrow"
-

--- a/src/raw/chevron-left/locales/nb/messages.po
+++ b/src/raw/chevron-left/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/chevron-left.js:2
 msgid "icon.title.chevron-left"
-msgstr ""
+msgstr "Pil venstre"

--- a/src/raw/chevron-right/locales/en/messages.po
+++ b/src/raw/chevron-right/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/chevron-right.js:2
 msgid "icon.title.chevron-right"
 msgstr "Rightward arrow"
-

--- a/src/raw/chevron-right/locales/nb/messages.po
+++ b/src/raw/chevron-right/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/chevron-right.js:2
 msgid "icon.title.chevron-right"
-msgstr ""
+msgstr "Pil høyre"

--- a/src/raw/chevron-up/locales/en/messages.po
+++ b/src/raw/chevron-up/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/chevron-up.js:2
 msgid "icon.title.chevron-up"
 msgstr "Upward arrow"
-

--- a/src/raw/chevron-up/locales/nb/messages.po
+++ b/src/raw/chevron-up/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/chevron-up.js:2
 msgid "icon.title.chevron-up"
-msgstr ""
+msgstr "Pil opp"

--- a/src/raw/circle-plus/locales/en/messages.po
+++ b/src/raw/circle-plus/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/circle-plus.js:2
 msgid "icon.title.circle-plus"
 msgstr "Circle with plus sign"
-

--- a/src/raw/circle-user/locales/en/messages.po
+++ b/src/raw/circle-user/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/circle-user.js:2
 msgid "icon.title.circle-user"
 msgstr "Circle with user profile"
-

--- a/src/raw/clock/locales/en/messages.po
+++ b/src/raw/clock/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/clock.js:2
 msgid "icon.title.clock"
 msgstr "Clock"
-

--- a/src/raw/close/locales/en/messages.po
+++ b/src/raw/close/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/close.js:2
 msgid "icon.title.close"
 msgstr "Cross"
-

--- a/src/raw/cog/locales/en/messages.po
+++ b/src/raw/cog/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/cog.js:2
 msgid "icon.title.cog"
 msgstr "Gear"
-

--- a/src/raw/color-palette/locales/en/messages.po
+++ b/src/raw/color-palette/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/color-palette.js:2
 msgid "icon.title.color-palette"
 msgstr "Color palette"
-

--- a/src/raw/cottage-plot/locales/en/messages.po
+++ b/src/raw/cottage-plot/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/cottage-plot.js:2
 msgid "icon.title.cottage-plot"
 msgstr "Dotted square with a highlighted house"
-

--- a/src/raw/credit-card/locales/en/messages.po
+++ b/src/raw/credit-card/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/credit-card.js:2
 msgid "icon.title.credit-card"
 msgstr "Credit card"
-

--- a/src/raw/cursor/locales/en/messages.po
+++ b/src/raw/cursor/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/cursor.js:2
 msgid "icon.title.cursor"
 msgstr "Mouse pointer over a circle"
-

--- a/src/raw/dating/locales/en/messages.po
+++ b/src/raw/dating/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/dating.js:2
 msgid "icon.title.dating"
 msgstr "Two hearts"
-

--- a/src/raw/diner/locales/en/messages.po
+++ b/src/raw/diner/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/diner.js:2
 msgid "icon.title.diner"
 msgstr "Knife and fork"
-

--- a/src/raw/discount/locales/en/messages.po
+++ b/src/raw/discount/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/discount.js:2
 msgid "icon.title.discount"
 msgstr "Percentage sign"
-

--- a/src/raw/dislike/locales/en/messages.po
+++ b/src/raw/dislike/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/dislike.js:2
 msgid "icon.title.dislike"
 msgstr "Thumbs down"
-

--- a/src/raw/door/locales/en/messages.po
+++ b/src/raw/door/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/door.js:2
 msgid "icon.title.door"
 msgstr "Door"
-

--- a/src/raw/dots/locales/en/messages.po
+++ b/src/raw/dots/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/dots.js:2
 msgid "icon.title.dots"
 msgstr "Three dots"
-

--- a/src/raw/double-bed/locales/en/messages.po
+++ b/src/raw/double-bed/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/double-bed.js:2
 msgid "icon.title.double-bed"
 msgstr "Double bed"
-

--- a/src/raw/download/locales/en/messages.po
+++ b/src/raw/download/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/download.js:2
 msgid "icon.title.download"
 msgstr "Arrow pointing down"
-

--- a/src/raw/drink/locales/en/messages.po
+++ b/src/raw/drink/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/drink.js:2
 msgid "icon.title.drink"
 msgstr "Cocktail glass"
-

--- a/src/raw/economy/locales/en/messages.po
+++ b/src/raw/economy/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/economy.js:2
 msgid "icon.title.economy"
 msgstr "Banknote and two coins"
-

--- a/src/raw/edit/locales/en/messages.po
+++ b/src/raw/edit/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/edit.js:2
 msgid "icon.title.edit"
 msgstr "Pencil"
-

--- a/src/raw/energy/locales/en/messages.po
+++ b/src/raw/energy/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/energy.js:2
 msgid "icon.title.energy"
 msgstr "Lightning bolt"
-

--- a/src/raw/engine-belt/locales/en/messages.po
+++ b/src/raw/engine-belt/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/engine-belt.js:2
 msgid "icon.title.engine-belt"
 msgstr "Fan belt"
-

--- a/src/raw/engine/locales/en/messages.po
+++ b/src/raw/engine/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/engine.js:2
 msgid "icon.title.engine"
 msgstr "Engine"
-

--- a/src/raw/exchange/locales/en/messages.po
+++ b/src/raw/exchange/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/exchange.js:2
 msgid "icon.title.exchange"
 msgstr "Two arrows forming a circle"
-

--- a/src/raw/expand/locales/en/messages.po
+++ b/src/raw/expand/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/expand.js:2
 msgid "icon.title.expand"
 msgstr "Arrows pointing outwards"
-

--- a/src/raw/eye-off/locales/en/messages.po
+++ b/src/raw/eye-off/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/eye-off.js:2
 msgid "icon.title.eye-off"
 msgstr "Closed eye"
-

--- a/src/raw/eye-on/locales/en/messages.po
+++ b/src/raw/eye-on/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/eye-on.js:2
 msgid "icon.title.eye-on"
 msgstr "Open eye"
-

--- a/src/raw/facebook/locales/en/messages.po
+++ b/src/raw/facebook/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/facebook.js:2
 msgid "icon.title.facebook"
 msgstr "Facebook logo"
-

--- a/src/raw/farm/locales/en/messages.po
+++ b/src/raw/farm/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/farm.js:2
 msgid "icon.title.farm"
 msgstr "Barn with silo and birds"
-

--- a/src/raw/favorite/locales/en/messages.po
+++ b/src/raw/favorite/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/favorite.js:2
 msgid "icon.title.favorite"
 msgstr "Heart"
-

--- a/src/raw/feedback/locales/en/messages.po
+++ b/src/raw/feedback/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/feedback.js:2
 msgid "icon.title.feedback"
 msgstr "Speech bubbles"
-

--- a/src/raw/file/locales/en/messages.po
+++ b/src/raw/file/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/file.js:2
 msgid "icon.title.file"
 msgstr "File folder"
-

--- a/src/raw/filter/locales/en/messages.po
+++ b/src/raw/filter/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/filter.js:2
 msgid "icon.title.filter"
 msgstr "Funnel"
-

--- a/src/raw/fireplace/locales/en/messages.po
+++ b/src/raw/fireplace/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/fireplace.js:2
 msgid "icon.title.fireplace"
 msgstr "Fireplace"
-

--- a/src/raw/fishing/locales/en/messages.po
+++ b/src/raw/fishing/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/fishing.js:2
 msgid "icon.title.fishing"
 msgstr "Fishing hook"
-

--- a/src/raw/fitness/locales/en/messages.po
+++ b/src/raw/fitness/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/fitness.js:2
 msgid "icon.title.fitness"
 msgstr "Running shoe"
-

--- a/src/raw/front-wheel-drive/locales/en/messages.po
+++ b/src/raw/front-wheel-drive/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/front-wheel-drive.js:2
 msgid "icon.title.front-wheel-drive"
 msgstr "Front-wheel drive"
-

--- a/src/raw/gas-diesel/locales/en/messages.po
+++ b/src/raw/gas-diesel/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/gas-diesel.js:2
 msgid "icon.title.gas-diesel"
 msgstr "Diesel pump"
-

--- a/src/raw/gas-fuel/locales/en/messages.po
+++ b/src/raw/gas-fuel/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/gas-fuel.js:2
 msgid "icon.title.gas-fuel"
 msgstr "Gas pump"
-

--- a/src/raw/gas-hybrid/locales/en/messages.po
+++ b/src/raw/gas-hybrid/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/gas-hybrid.js:2
 msgid "icon.title.gas-hybrid"
 msgstr "Circle with a plug and a drop"
-

--- a/src/raw/graph-line/locales/en/messages.po
+++ b/src/raw/graph-line/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/graph-line.js:2
 msgid "icon.title.graph-line"
 msgstr "Line graph"
-

--- a/src/raw/graph-pie/locales/en/messages.po
+++ b/src/raw/graph-pie/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/graph-pie.js:2
 msgid "icon.title.graph-pie"
 msgstr "Pie chart"
-

--- a/src/raw/grid/locales/en/messages.po
+++ b/src/raw/grid/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/grid.js:2
 msgid "icon.title.grid"
 msgstr "Grid of squares"
-

--- a/src/raw/grill/locales/en/messages.po
+++ b/src/raw/grill/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/grill.js:2
 msgid "icon.title.grill"
 msgstr "Charcoal grill"
-

--- a/src/raw/heart-rate/locales/en/messages.po
+++ b/src/raw/heart-rate/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/heart-rate.js:2
 msgid "icon.title.heart-rate"
 msgstr "Heart with heart rate indicator"
-

--- a/src/raw/hiking/locales/en/messages.po
+++ b/src/raw/hiking/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/hiking.js:2
 msgid "icon.title.hiking"
 msgstr "Forest path"
-

--- a/src/raw/history/locales/en/messages.po
+++ b/src/raw/history/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/history.js:2
 msgid "icon.title.history"
 msgstr "Clock with arrow going counterclockwise"
-

--- a/src/raw/honk/locales/en/messages.po
+++ b/src/raw/honk/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/honk.js:2
 msgid "icon.title.honk"
 msgstr "Car horn"
-

--- a/src/raw/hotel/locales/en/messages.po
+++ b/src/raw/hotel/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/hotel.js:2
 msgid "icon.title.hotel"
 msgstr "Hotel building"
-

--- a/src/raw/house-bed/locales/en/messages.po
+++ b/src/raw/house-bed/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/house-bed.js:2
 msgid "icon.title.house-bed"
 msgstr "Bed with a roof over it"
-

--- a/src/raw/house-cabin/locales/en/messages.po
+++ b/src/raw/house-cabin/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/house-cabin.js:2
 msgid "icon.title.house-cabin"
 msgstr "Cabin"
-

--- a/src/raw/house-modern/locales/en/messages.po
+++ b/src/raw/house-modern/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/house-modern.js:2
 msgid "icon.title.house-modern"
 msgstr "Modern house"
-

--- a/src/raw/house-person/locales/en/messages.po
+++ b/src/raw/house-person/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/house-person.js:2
 msgid "icon.title.house-person"
 msgstr "House with a person"
-

--- a/src/raw/image/locales/en/messages.po
+++ b/src/raw/image/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/image.js:2
 msgid "icon.title.image"
 msgstr "Image"
-

--- a/src/raw/info/locales/en/messages.po
+++ b/src/raw/info/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/info.js:2
 msgid "icon.title.info"
 msgstr "Information circle"
-

--- a/src/raw/instagram/locales/en/messages.po
+++ b/src/raw/instagram/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/instagram.js:2
 msgid "icon.title.instagram"
 msgstr "Instagram logo"
-

--- a/src/raw/job/locales/en/messages.po
+++ b/src/raw/job/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/job.js:2
 msgid "icon.title.job"
 msgstr "Document folder"
-

--- a/src/raw/keys/locales/en/messages.po
+++ b/src/raw/keys/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/keys.js:2
 msgid "icon.title.keys"
 msgstr "Two keys on a keyring"
-

--- a/src/raw/krone/locales/en/messages.po
+++ b/src/raw/krone/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/krone.js:2
 msgid "icon.title.krone"
 msgstr "Circle with KR"
-

--- a/src/raw/landscape/locales/en/messages.po
+++ b/src/raw/landscape/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/landscape.js:2
 msgid "icon.title.landscape"
 msgstr "Sun and mountains"
-

--- a/src/raw/laundry/locales/en/messages.po
+++ b/src/raw/laundry/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/laundry.js:2
 msgid "icon.title.laundry"
 msgstr "Washing machine"
-

--- a/src/raw/layers/locales/en/messages.po
+++ b/src/raw/layers/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/layers.js:2
 msgid "icon.title.layers"
 msgstr "Three squares overlapping"
-

--- a/src/raw/leaf/locales/en/messages.po
+++ b/src/raw/leaf/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/leaf.js:2
 msgid "icon.title.leaf"
 msgstr "Leaf"
-

--- a/src/raw/lift/locales/en/messages.po
+++ b/src/raw/lift/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/lift.js:2
 msgid "icon.title.lift"
 msgstr "Elevator"
-

--- a/src/raw/like/locales/en/messages.po
+++ b/src/raw/like/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/like.js:2
 msgid "icon.title.like"
 msgstr "Thumbs-up"
-

--- a/src/raw/link-external/locales/en/messages.po
+++ b/src/raw/link-external/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/link-external.js:2
 msgid "icon.title.link-external"
 msgstr "Square with an upward arrow to the right"
-

--- a/src/raw/link/locales/en/messages.po
+++ b/src/raw/link/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/link.js:2
 msgid "icon.title.link"
 msgstr "Chain link"
-

--- a/src/raw/list-sort/locales/en/messages.po
+++ b/src/raw/list-sort/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/list-sort.js:2
 msgid "icon.title.list-sort"
 msgstr "Vertical list with sorting arrow"
-

--- a/src/raw/lock-shield/locales/en/messages.po
+++ b/src/raw/lock-shield/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/lock-shield.js:2
 msgid "icon.title.lock-shield"
 msgstr "Shield with padlock"
-

--- a/src/raw/mail/locales/en/messages.po
+++ b/src/raw/mail/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/mail.js:2
 msgid "icon.title.mail"
 msgstr "Envelope with letter"
-

--- a/src/raw/mailbox/locales/en/messages.po
+++ b/src/raw/mailbox/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/mailbox.js:2
 msgid "icon.title.mailbox"
 msgstr "Mailbox with a flag indicating new mail"
-

--- a/src/raw/manual/locales/en/messages.po
+++ b/src/raw/manual/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/manual.js:2
 msgid "icon.title.manual"
 msgstr "Manual transmission gearbox"
-

--- a/src/raw/map/locales/en/messages.po
+++ b/src/raw/map/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/map.js:2
 msgid "icon.title.map"
 msgstr "Map"
-

--- a/src/raw/market/locales/en/messages.po
+++ b/src/raw/market/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/market.js:2
 msgid "icon.title.market"
 msgstr "Sofa"
-

--- a/src/raw/measure/locales/en/messages.po
+++ b/src/raw/measure/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/measure.js:2
 msgid "icon.title.measure"
 msgstr "Dotted square with measuring arrows"
-

--- a/src/raw/message/locales/en/messages.po
+++ b/src/raw/message/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/message.js:2
 msgid "icon.title.message"
 msgstr "Chat bubble"
-

--- a/src/raw/messages/locales/en/messages.po
+++ b/src/raw/messages/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/messages.js:2
 msgid "icon.title.messages"
 msgstr "Speech bubbles"
-

--- a/src/raw/minus/locales/en/messages.po
+++ b/src/raw/minus/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/minus.js:2
 msgid "icon.title.minus"
 msgstr "Minus"
-

--- a/src/raw/motorcycle/locales/en/messages.po
+++ b/src/raw/motorcycle/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/motorcycle.js:2
 msgid "icon.title.motorcycle"
 msgstr "Motorcycle"
-

--- a/src/raw/mountain/locales/en/messages.po
+++ b/src/raw/mountain/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/mountain.js:2
 msgid "icon.title.mountain"
 msgstr "Mountain"
-

--- a/src/raw/nettbil/locales/en/messages.po
+++ b/src/raw/nettbil/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/nettbil.js:2
 msgid "icon.title.nettbil"
 msgstr "Two circles with a semicircle above"
-

--- a/src/raw/new-ad/locales/en/messages.po
+++ b/src/raw/new-ad/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/new-ad.js:2
 msgid "icon.title.new-ad"
 msgstr "Sheet with image, headline, and highlighted plus sign"
-

--- a/src/raw/no-smoking/locales/en/messages.po
+++ b/src/raw/no-smoking/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/no-smoking.js:2
 msgid "icon.title.no-smoking"
 msgstr "Overlaid cigarette"
-

--- a/src/raw/norwegian-motor/locales/en/messages.po
+++ b/src/raw/norwegian-motor/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/norwegian-motor.js:2
 msgid "icon.title.norwegian-motor"
 msgstr "Circle with NBF"
-

--- a/src/raw/office-desk/locales/en/messages.po
+++ b/src/raw/office-desk/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/office-desk.js:2
 msgid "icon.title.office-desk"
 msgstr "Office desk with a computer screen"
-

--- a/src/raw/paint-roller/locales/en/messages.po
+++ b/src/raw/paint-roller/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/paint-roller.js:2
 msgid "icon.title.paint-roller"
 msgstr "Paint roller in action"
-

--- a/src/raw/parking/locales/en/messages.po
+++ b/src/raw/parking/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/parking.js:2
 msgid "icon.title.parking"
 msgstr "Parking sign"
-

--- a/src/raw/paw/locales/en/messages.po
+++ b/src/raw/paw/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/paw.js:2
 msgid "icon.title.paw"
 msgstr "Cat's paw"
-

--- a/src/raw/phone-new/locales/en/messages.po
+++ b/src/raw/phone-new/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/phone-new.js:2
 msgid "icon.title.phone-new"
 msgstr "Smartphone"
-

--- a/src/raw/phone-scratched/locales/en/messages.po
+++ b/src/raw/phone-scratched/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/phone-scratched.js:2
 msgid "icon.title.phone-scratched"
 msgstr "Smartphone with three scratches on the glass"
-

--- a/src/raw/phone-used/locales/en/messages.po
+++ b/src/raw/phone-used/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/phone-used.js:2
 msgid "icon.title.phone-used"
 msgstr "Smartphone with three scratches on the glass"
-

--- a/src/raw/pin-marker/locales/en/messages.po
+++ b/src/raw/pin-marker/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/pin-marker.js:2
 msgid "icon.title.pin-marker"
 msgstr "Map pin"
-

--- a/src/raw/pin-round/locales/en/messages.po
+++ b/src/raw/pin-round/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/pin-round.js:2
 msgid "icon.title.pin-round"
 msgstr "Map pin with a shadow underneath"
-

--- a/src/raw/plane-ticket/locales/en/messages.po
+++ b/src/raw/plane-ticket/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/plane-ticket.js:2
 msgid "icon.title.plane-ticket"
 msgstr "Hand with plane ticket"
-

--- a/src/raw/play/locales/en/messages.po
+++ b/src/raw/play/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/play.js:2
 msgid "icon.title.play"
 msgstr "Play button"
-

--- a/src/raw/playhouse/locales/en/messages.po
+++ b/src/raw/playhouse/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/playhouse.js:2
 msgid "icon.title.playhouse"
 msgstr "Climbing frame"
-

--- a/src/raw/plots/locales/en/messages.po
+++ b/src/raw/plots/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/plots.js:2
 msgid "icon.title.plots"
 msgstr "Dotted square with a highlighted smaller square"
-

--- a/src/raw/plus/locales/en/messages.po
+++ b/src/raw/plus/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/plus.js:2
 msgid "icon.title.plus"
 msgstr "Plus sign"
-

--- a/src/raw/product-blink/locales/en/messages.po
+++ b/src/raw/product-blink/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/product-blink.js:2
 msgid "icon.title.product-blink"
 msgstr "Rocket"
-

--- a/src/raw/product-bump/locales/en/messages.po
+++ b/src/raw/product-bump/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/product-bump.js:2
 msgid "icon.title.product-bump"
 msgstr "Image with text highlighted by an upward arrow"
-

--- a/src/raw/product-carousel/locales/en/messages.po
+++ b/src/raw/product-carousel/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/product-carousel.js:2
 msgid "icon.title.product-carousel"
 msgstr "Highlighted vertical rectangle with two rectangles in the background"
-

--- a/src/raw/product-highlight-listing/locales/en/messages.po
+++ b/src/raw/product-highlight-listing/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/product-highlight-listing.js:2
 msgid "icon.title.product-highlight-listing"
 msgstr "Text with highlighted image"
-

--- a/src/raw/product-nabolagsprofil/locales/en/messages.po
+++ b/src/raw/product-nabolagsprofil/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/product-nabolagsprofil.js:2
 msgid "icon.title.product-nabolagsprofil"
 msgstr "House with a highlighted map pin"
-

--- a/src/raw/product-no-ads/locales/en/messages.po
+++ b/src/raw/product-no-ads/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/product-no-ads.js:2
 msgid "icon.title.product-no-ads"
 msgstr "Loudspeaker"
-

--- a/src/raw/product-starred/locales/en/messages.po
+++ b/src/raw/product-starred/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/product-starred.js:2
 msgid "icon.title.product-starred"
 msgstr "Three stars with text below"
-

--- a/src/raw/product-top/locales/en/messages.po
+++ b/src/raw/product-top/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/product-top.js:2
 msgid "icon.title.product-top"
 msgstr "Arrow pointing to an image with text below"
-

--- a/src/raw/propeller/locales/en/messages.po
+++ b/src/raw/propeller/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/propeller.js:2
 msgid "icon.title.propeller"
 msgstr "Spinning propeller"
-

--- a/src/raw/question/locales/en/messages.po
+++ b/src/raw/question/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/question.js:2
 msgid "icon.title.question"
 msgstr "Question mark"
-

--- a/src/raw/rating-empty/locales/en/messages.po
+++ b/src/raw/rating-empty/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/rating-empty.js:2
 msgid "icon.title.rating-empty"
 msgstr "Empty blue star"
-

--- a/src/raw/rating-empty/locales/nb/messages.po
+++ b/src/raw/rating-empty/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/rating-empty.js:2
 msgid "icon.title.rating-empty"
-msgstr ""
+msgstr "Tom blå stjerne"

--- a/src/raw/rating-full/locales/en/messages.po
+++ b/src/raw/rating-full/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/rating-full.js:2
 msgid "icon.title.rating-full"
 msgstr "Full blue star"
-

--- a/src/raw/rating-full/locales/nb/messages.po
+++ b/src/raw/rating-full/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/rating-full.js:2
 msgid "icon.title.rating-full"
-msgstr ""
+msgstr "Full blå stjerne"

--- a/src/raw/rating-half/locales/en/messages.po
+++ b/src/raw/rating-half/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/rating-half.js:2
 msgid "icon.title.rating-half"
 msgstr "Half full blue star"
-

--- a/src/raw/rating-half/locales/nb/messages.po
+++ b/src/raw/rating-half/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/rating-half.js:2
 msgid "icon.title.rating-half"
-msgstr ""
+msgstr "Halvfull blå stjerne"

--- a/src/raw/real-estate/locales/en/messages.po
+++ b/src/raw/real-estate/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/real-estate.js:2
 msgid "icon.title.real-estate"
 msgstr "House with a garden"
-

--- a/src/raw/refresh/locales/en/messages.po
+++ b/src/raw/refresh/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/refresh.js:2
 msgid "icon.title.refresh"
 msgstr "Circular arrow"
-

--- a/src/raw/room-service/locales/en/messages.po
+++ b/src/raw/room-service/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/room-service.js:2
 msgid "icon.title.room-service"
 msgstr "Gloved hand and serving tray with a dome"
-

--- a/src/raw/sailboat/locales/en/messages.po
+++ b/src/raw/sailboat/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/sailboat.js:2
 msgid "icon.title.sailboat"
 msgstr "Two birds and a sailboat on water"
-

--- a/src/raw/sailing/locales/en/messages.po
+++ b/src/raw/sailing/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/sailing.js:2
 msgid "icon.title.sailing"
 msgstr "Sailboat on water"
-

--- a/src/raw/sauna/locales/en/messages.po
+++ b/src/raw/sauna/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/sauna.js:2
 msgid "icon.title.sauna"
 msgstr "House with heat waves"
-

--- a/src/raw/search-favorites/locales/en/messages.po
+++ b/src/raw/search-favorites/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/search-favorites.js:2
 msgid "icon.title.search-favorites"
 msgstr "Magnifying glass with a heart"
-

--- a/src/raw/search/locales/en/messages.po
+++ b/src/raw/search/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/search.js:2
 msgid "icon.title.search"
 msgstr "Magnifying glass"
-

--- a/src/raw/seat/locales/en/messages.po
+++ b/src/raw/seat/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/seat.js:2
 msgid "icon.title.seat"
 msgstr "Airplane seat"
-

--- a/src/raw/send/locales/en/messages.po
+++ b/src/raw/send/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/send.js:2
 msgid "icon.title.send"
 msgstr "Paper plane"
-

--- a/src/raw/service/locales/en/messages.po
+++ b/src/raw/service/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/service.js:2
 msgid "icon.title.service"
 msgstr "Rotating arrow with a wrench"
-

--- a/src/raw/share/locales/en/messages.po
+++ b/src/raw/share/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/share.js:2
 msgid "icon.title.share"
 msgstr "Share icon"
-

--- a/src/raw/shower/locales/en/messages.po
+++ b/src/raw/shower/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/shower.js:2
 msgid "icon.title.shower"
 msgstr "Running shower head"
-

--- a/src/raw/skyscraper/locales/en/messages.po
+++ b/src/raw/skyscraper/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/skyscraper.js:2
 msgid "icon.title.skyscraper"
 msgstr "Two skyscrapers with a cloud above"
-

--- a/src/raw/smart-phone/locales/en/messages.po
+++ b/src/raw/smart-phone/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/smart-phone.js:2
 msgid "icon.title.smartphone"
 msgstr "Smartphone"
-

--- a/src/raw/smiley-good/locales/en/messages.po
+++ b/src/raw/smiley-good/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/smiley-good.js:2
 msgid "icon.title.smiley-good"
 msgstr "Good smiley face"
-

--- a/src/raw/smiley-happy/locales/en/messages.po
+++ b/src/raw/smiley-happy/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/smiley-happy.js:2
 msgid "icon.title.smiley-happy"
 msgstr "Happy face"
-

--- a/src/raw/smiley-neutral/locales/en/messages.po
+++ b/src/raw/smiley-neutral/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/smiley-neutral.js:2
 msgid "icon.title.smiley-neutral"
 msgstr "Neutral face"
-

--- a/src/raw/smiley-sad/locales/en/messages.po
+++ b/src/raw/smiley-sad/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/smiley-sad.js:2
 msgid "icon.title.smiley-sad"
 msgstr "Sad face"
-

--- a/src/raw/sorting/locales/en/messages.po
+++ b/src/raw/sorting/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/sorting.js:2
 msgid "icon.title.sorting"
 msgstr "Sorting arrows"
-

--- a/src/raw/spa/locales/en/messages.po
+++ b/src/raw/spa/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/spa.js:2
 msgid "icon.title.spa"
 msgstr "Water lily"
-

--- a/src/raw/speedometer/locales/en/messages.po
+++ b/src/raw/speedometer/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/speedometer.js:2
 msgid "icon.title.speedometer"
 msgstr "Speedometer"
-

--- a/src/raw/stairs/locales/en/messages.po
+++ b/src/raw/stairs/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/stairs.js:2
 msgid "icon.title.stairs"
 msgstr "Stairs with diagonal arrow up"
-

--- a/src/raw/star-check/locales/en/messages.po
+++ b/src/raw/star-check/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/star-check.js:2
 msgid "icon.title.star-check"
 msgstr "Star with highlighted checkmark"
-

--- a/src/raw/store/locales/en/messages.po
+++ b/src/raw/store/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/store.js:2
 msgid "icon.title.store"
 msgstr "Storefront building"
-

--- a/src/raw/stove/locales/en/messages.po
+++ b/src/raw/stove/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/stove.js:2
 msgid "icon.title.stove"
 msgstr "Stove"
-

--- a/src/raw/suitcase/locales/en/messages.po
+++ b/src/raw/suitcase/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/suitcase.js:2
 msgid "icon.title.suitcase"
 msgstr "Suitcase"
-

--- a/src/raw/support/locales/en/messages.po
+++ b/src/raw/support/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/support.js:2
 msgid "icon.title.support"
 msgstr "Customer support headset"
-

--- a/src/raw/swimming/locales/en/messages.po
+++ b/src/raw/swimming/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/swimming.js:2
 msgid "icon.title.swimming"
 msgstr "Swimming person"
-

--- a/src/raw/table-info/locales/en/messages.po
+++ b/src/raw/table-info/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/table-info.js:2
 msgid "icon.title.table-info"
 msgstr "Circle with letter \"I\""
-

--- a/src/raw/table-sort-down/locales/en/messages.po
+++ b/src/raw/table-sort-down/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/table-sort-down.js:2
 msgid "icon.title.table-sort-down"
 msgstr "Downward-pointing arrow"
-

--- a/src/raw/table-sort-up/locales/en/messages.po
+++ b/src/raw/table-sort-up/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/table-sort-up.js:2
 msgid "icon.title.table-sort-up"
 msgstr "Upward-pointing arrow"
-

--- a/src/raw/tag/locales/en/messages.po
+++ b/src/raw/tag/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/tag.js:2
 msgid "icon.title.tag"
 msgstr "Tag"
-

--- a/src/raw/task-list/locales/en/messages.po
+++ b/src/raw/task-list/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/task-list.js:2
 msgid "icon.title.task-list"
 msgstr "List with checkmark"
-

--- a/src/raw/theater/locales/en/messages.po
+++ b/src/raw/theater/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/theater.js:2
 msgid "icon.title.theater"
 msgstr "Costume mask with a smiley face"
-

--- a/src/raw/three-sixty/locales/en/messages.po
+++ b/src/raw/three-sixty/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/three-sixty.js:2
 msgid "icon.title.three-sixty"
 msgstr "Right-pointing rotating arrow with a house"
-

--- a/src/raw/torget-browser/locales/en/messages.po
+++ b/src/raw/torget-browser/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/torget-browser.js:2
 msgid "icon.title.torget-browser"
 msgstr "Browser window with a t-shirt and a highlighted mouse pointer"
-

--- a/src/raw/torget-delivery/locales/en/messages.po
+++ b/src/raw/torget-delivery/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/torget-delivery.js:2
 msgid "icon.title.torget-delivery"
 msgstr "Hand holding a small box"
-

--- a/src/raw/torget-headset/locales/en/messages.po
+++ b/src/raw/torget-headset/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/torget-headset.js:2
 msgid "icon.title.torget-headset"
 msgstr "Headphones"
-

--- a/src/raw/torget-lamp/locales/en/messages.po
+++ b/src/raw/torget-lamp/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/torget-lamp.js:2
 msgid "icon.title.torget-lamp"
 msgstr "Floor lamp"
-

--- a/src/raw/torget-mixer/locales/en/messages.po
+++ b/src/raw/torget-mixer/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/torget-mixer.js:2
 msgid "icon.title.torget-mixer"
 msgstr "Food mixer"
-

--- a/src/raw/torget-shipping/locales/en/messages.po
+++ b/src/raw/torget-shipping/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/torget-shipping.js:2
 msgid "icon.title.torget-shipping"
 msgstr "Truck in motion"
-

--- a/src/raw/torget-shopping/locales/en/messages.po
+++ b/src/raw/torget-shopping/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/torget-shopping.js:2
 msgid "icon.title.torget-shopping"
 msgstr "Shopping cart"
-

--- a/src/raw/torget-users/locales/en/messages.po
+++ b/src/raw/torget-users/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/torget-users.js:2
 msgid "icon.title.torget-users"
 msgstr "Three people"
-

--- a/src/raw/torget-verified/locales/en/messages.po
+++ b/src/raw/torget-verified/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/torget-verified.js:2
 msgid "icon.title.torget-verified"
 msgstr "Browser with highlighted shield in the bottom right corner"
-

--- a/src/raw/town-house/locales/en/messages.po
+++ b/src/raw/town-house/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/town-house.js:2
 msgid "icon.title.town-house"
 msgstr "Two townhouses"
-

--- a/src/raw/tractor/locales/en/messages.po
+++ b/src/raw/tractor/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/tractor.js:2
 msgid "icon.title.tractor"
 msgstr "Tractor"
-

--- a/src/raw/triangle/locales/en/messages.po
+++ b/src/raw/triangle/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/triangle.js:2
 msgid "icon.title.triangle"
 msgstr "Warning triangle"
-

--- a/src/raw/tv/locales/en/messages.po
+++ b/src/raw/tv/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/tv.js:2
 msgid "icon.title.tv"
 msgstr "Flat screen TV"
-

--- a/src/raw/tv/locales/nb/messages.po
+++ b/src/raw/tv/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/tv.js:2
 msgid "icon.title.tv"
-msgstr ""
+msgstr "Flatskjerm"

--- a/src/raw/twitter/locales/en/messages.po
+++ b/src/raw/twitter/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/twitter.js:2
 msgid "icon.title.twitter"
 msgstr "Twitter logo"
-

--- a/src/raw/up/locales/en/messages.po
+++ b/src/raw/up/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/up.js:2
 msgid "icon.title.up"
 msgstr "Square with arrow pointing up"
-

--- a/src/raw/upload/locales/en/messages.po
+++ b/src/raw/upload/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/upload.js:2
 msgid "icon.title.upload"
 msgstr "Upload arrow"
-

--- a/src/raw/user-woman/locales/en/messages.po
+++ b/src/raw/user-woman/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/user-woman.js:2
 msgid "icon.title.user-woman"
 msgstr "Woman with braids"
-

--- a/src/raw/user/locales/en/messages.po
+++ b/src/raw/user/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/user.js:2
 msgid "icon.title.user"
 msgstr "User profile"
-

--- a/src/raw/users/locales/en/messages.po
+++ b/src/raw/users/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/users.js:2
 msgid "icon.title.users"
 msgstr "Group of users"
-

--- a/src/raw/van/locales/en/messages.po
+++ b/src/raw/van/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/van.js:2
 msgid "icon.title.van"
 msgstr "Camper van"
-

--- a/src/raw/verification/locales/en/messages.po
+++ b/src/raw/verification/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/verification.js:2
 msgid "icon.title.verification"
 msgstr "Blue shield with checkmark"
-

--- a/src/raw/wallet/locales/en/messages.po
+++ b/src/raw/wallet/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/wallet.js:2
 msgid "icon.title.wallet"
 msgstr "Wallet"
-

--- a/src/raw/warranty/locales/en/messages.po
+++ b/src/raw/warranty/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/warranty.js:2
 msgid "icon.title.warranty"
 msgstr "Ribbon with checkmark"
-

--- a/src/raw/wheelchair/locales/en/messages.po
+++ b/src/raw/wheelchair/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/wheelchair.js:2
 msgid "icon.title.wheelchair"
 msgstr "Wheelchair"
-

--- a/src/raw/wifi/locales/en/messages.po
+++ b/src/raw/wifi/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/wifi.js:2
 msgid "icon.title.wifi"
 msgstr "Wi-Fi symbol"
-

--- a/src/raw/woods/locales/en/messages.po
+++ b/src/raw/woods/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/woods.js:2
 msgid "icon.title.woods"
 msgstr "Two spruce trees"
-

--- a/src/raw/youtube/locales/en/messages.po
+++ b/src/raw/youtube/locales/en/messages.po
@@ -19,4 +19,3 @@ msgstr ""
 #: scripts/temp/youtube.js:2
 msgid "icon.title.youtube"
 msgstr "YouTube logo"
-


### PR DESCRIPTION
Still missing titles for `honk, list-sort, messages, task-list` but we don't have from previous fabric-icons