### PR TITLE
revert(crowdin.yml): revert formatting that makes file format invalid

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,10 +1,1179 @@
-|
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_API_TOKEN
+base_url_env: CROWDIN_BASE_URL
+base_path: "."
 
-  project_id_env: CROWDIN_PROJECT_ID
-  api_token_env: CROWDIN_API_TOKEN
-  base_url_env: CROWDIN_BASE_URL
-  base_path: "."
-
-  preserve_hierarchy: true
-  files:
-    [{"source":"/src/raw/youtube/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/youtube/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/woods/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/woods/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/wifi/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/wifi/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/wheelchair/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/wheelchair/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/warranty/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/warranty/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/wallet/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/wallet/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/verification/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/verification/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/van/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/van/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/users/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/users/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/user-woman/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/user-woman/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/user/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/user/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/upload/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/upload/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/up/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/up/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/twitter/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/twitter/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/tv/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/tv/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/triangle/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/triangle/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/tractor/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/tractor/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/town-house/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/town-house/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/torget-verified/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/torget-verified/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/torget-users/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/torget-users/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/torget-shopping/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/torget-shopping/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/torget-shipping/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/torget-shipping/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/torget-mixer/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/torget-mixer/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/torget-lamp/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/torget-lamp/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/torget-headset/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/torget-headset/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/torget-delivery/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/torget-delivery/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/torget-browser/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/torget-browser/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/three-sixty/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/three-sixty/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/theater/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/theater/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/task-list/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/task-list/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/tag/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/tag/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/table-sort-up/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/table-sort-up/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/table-sort-down/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/table-sort-down/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/table-info/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/table-info/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/swimming/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/swimming/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/support/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/support/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/suitcase/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/suitcase/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/stove/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/stove/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/store/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/store/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/star-check/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/star-check/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/stairs/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/stairs/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/speedometer/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/speedometer/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/spa/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/spa/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/sorting/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/sorting/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/smiley-sad/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/smiley-sad/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/smiley-neutral/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/smiley-neutral/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/smiley-happy/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/smiley-happy/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/smiley-good/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/smiley-good/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/smart-phone/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/smart-phone/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/skyscraper/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/skyscraper/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/shower/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/shower/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/share/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/share/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/service/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/service/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/send/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/send/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/seat/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/seat/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/search-favorites/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/search-favorites/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/search/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/search/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/sauna/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/sauna/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/sailing/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/sailing/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/sailboat/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/sailboat/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/room-service/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/room-service/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/refresh/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/refresh/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/real-estate/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/real-estate/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/rating-half/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/rating-half/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/rating-full/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/rating-full/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/rating-empty/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/rating-empty/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/question/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/question/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/propeller/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/propeller/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/product-top/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/product-top/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/product-starred/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/product-starred/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/product-no-ads/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/product-no-ads/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/product-nabolagsprofil/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/product-nabolagsprofil/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/product-highlight-listing/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/product-highlight-listing/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/product-carousel/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/product-carousel/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/product-bump/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/product-bump/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/product-blink/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/product-blink/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/plus/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/plus/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/plots/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/plots/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/playhouse/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/playhouse/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/play/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/play/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/plane-ticket/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/plane-ticket/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/pin-round/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/pin-round/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/pin-marker/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/pin-marker/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/phone-used/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/phone-used/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/phone-scratched/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/phone-scratched/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/phone-new/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/phone-new/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/paw/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/paw/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/parking/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/parking/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/paint-roller/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/paint-roller/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/office-desk/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/office-desk/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/norwegian-motor/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/norwegian-motor/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/no-smoking/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/no-smoking/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/new-ad/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/new-ad/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/nettbil/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/nettbil/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/mountain/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/mountain/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/motorcycle/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/motorcycle/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/minus/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/minus/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/messages/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/messages/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/message/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/message/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/measure/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/measure/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/market/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/market/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/map/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/map/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/manual/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/manual/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/mailbox/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/mailbox/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/mail/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/mail/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/lock-shield/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/lock-shield/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/list-sort/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/list-sort/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/link-external/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/link-external/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/link/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/link/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/like/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/like/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/lift/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/lift/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/leaf/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/leaf/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/layers/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/layers/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/laundry/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/laundry/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/landscape/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/landscape/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/krone/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/krone/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/keys/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/keys/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/job/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/job/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/instagram/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/instagram/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/info/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/info/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/image/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/image/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/house-person/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/house-person/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/house-modern/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/house-modern/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/house-cabin/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/house-cabin/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/house-bed/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/house-bed/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/hotel/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/hotel/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/honk/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/honk/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/history/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/history/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/hiking/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/hiking/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/heart-rate/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/heart-rate/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/grill/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/grill/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/grid/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/grid/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/graph-pie/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/graph-pie/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/graph-line/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/graph-line/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/gas-hybrid/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/gas-hybrid/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/gas-fuel/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/gas-fuel/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/gas-diesel/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/gas-diesel/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/front-wheel-drive/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/front-wheel-drive/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/fitness/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/fitness/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/fishing/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/fishing/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/fireplace/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/fireplace/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/filter/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/filter/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/file/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/file/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/feedback/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/feedback/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/favorite/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/favorite/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/farm/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/farm/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/facebook/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/facebook/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/eye-on/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/eye-on/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/eye-off/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/eye-off/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/expand/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/expand/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/exchange/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/exchange/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/engine-belt/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/engine-belt/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/engine/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/engine/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/energy/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/energy/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/edit/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/edit/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/economy/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/economy/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/drink/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/drink/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/download/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/download/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/double-bed/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/double-bed/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/dots/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/dots/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/door/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/door/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/dislike/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/dislike/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/discount/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/discount/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/diner/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/diner/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/dating/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/dating/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/cursor/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/cursor/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/credit-card/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/credit-card/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/cottage-plot/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/cottage-plot/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/color-palette/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/color-palette/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/cog/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/cog/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/close/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/close/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/clock/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/clock/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/circle-user/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/circle-user/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/circle-plus/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/circle-plus/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/chevron-up/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/chevron-up/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/chevron-right/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/chevron-right/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/chevron-left/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/chevron-left/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/chevron-down/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/chevron-down/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/chevron-double-right/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/chevron-double-right/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/chevron-double-left/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/chevron-double-left/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/checklist/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/checklist/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/check/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/check/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/chat-support/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/chat-support/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/chat-request/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/chat-request/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/charter/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/charter/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/charger/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/charger/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/chainsaw/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/chainsaw/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/cart/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/cart/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/car-subscription/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/car-subscription/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/car-service/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/car-service/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/car-rent/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/car-rent/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/car-key/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/car-key/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/car/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/car/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/camping/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/camping/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/camera/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/camera/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/calendar/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/calendar/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/calculator/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/calculator/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/cabin-hut/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/cabin-hut/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/cabin/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/cabin/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/bus/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/bus/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/burger/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/burger/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/bulldozer/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/bulldozer/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/bulb/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/bulb/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/building-plot/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/building-plot/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/building/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/building/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/bookmark/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/bookmark/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/bolt/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/bolt/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/boat-length/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/boat-length/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/block/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/block/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/bin/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/bin/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/bell/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/bell/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/beach/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/beach/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/battery-half-full/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/battery-half-full/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/battery-full/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/battery-full/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/battery-empty/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/battery-empty/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/bank-ident/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/bank-ident/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/bank-id/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/bank-id/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/bank/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/bank/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/bag/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/bag/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/back-wheel-drive/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/back-wheel-drive/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/automatic/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/automatic/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/attachment/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/attachment/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/archway/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/archway/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/all-wheel-drive/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/all-wheel-drive/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/alert-warning/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/alert-warning/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/alert-success/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/alert-success/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/alert-info/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/alert-info/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/alert-error/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/alert-error/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/alert/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/alert/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/airplane-hotel/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/airplane-hotel/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/airplane/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/airplane/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/air-con/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/air-con/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/ads/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/ads/locales/%two_letters_code%/messages.po"},{"source":"/src/raw/active-ads/locales/en/messages.po","dest":"/icons/**/%original_file_name%","translation":"/src/raw/active-ads/locales/%two_letters_code%/messages.po"}]
+preserve_hierarchy: true
+files:
+  [
+    {
+      "source": "/src/raw/youtube/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/youtube/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/woods/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/woods/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/wifi/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/wifi/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/wheelchair/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/wheelchair/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/warranty/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/warranty/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/wallet/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/wallet/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/verification/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/verification/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/van/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/van/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/users/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/users/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/user-woman/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/user-woman/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/user/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/user/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/upload/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/upload/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/up/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/up/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/twitter/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/twitter/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/tv/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/tv/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/triangle/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/triangle/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/tractor/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/tractor/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/town-house/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/town-house/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/torget-verified/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/torget-verified/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/torget-users/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/torget-users/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/torget-shopping/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/torget-shopping/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/torget-shipping/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/torget-shipping/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/torget-mixer/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/torget-mixer/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/torget-lamp/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/torget-lamp/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/torget-headset/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/torget-headset/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/torget-delivery/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/torget-delivery/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/torget-browser/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/torget-browser/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/three-sixty/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/three-sixty/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/theater/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/theater/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/task-list/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/task-list/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/tag/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/tag/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/table-sort-up/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/table-sort-up/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/table-sort-down/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/table-sort-down/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/table-info/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/table-info/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/swimming/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/swimming/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/support/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/support/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/suitcase/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/suitcase/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/stove/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/stove/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/store/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/store/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/star-check/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/star-check/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/stairs/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/stairs/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/speedometer/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/speedometer/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/spa/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/spa/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/sorting/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/sorting/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/smiley-sad/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/smiley-sad/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/smiley-neutral/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/smiley-neutral/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/smiley-happy/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/smiley-happy/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/smiley-good/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/smiley-good/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/smart-phone/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/smart-phone/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/skyscraper/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/skyscraper/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/shower/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/shower/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/share/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/share/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/service/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/service/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/send/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/send/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/seat/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/seat/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/search-favorites/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/search-favorites/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/search/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/search/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/sauna/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/sauna/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/sailing/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/sailing/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/sailboat/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/sailboat/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/room-service/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/room-service/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/refresh/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/refresh/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/real-estate/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/real-estate/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/rating-half/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/rating-half/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/rating-full/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/rating-full/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/rating-empty/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/rating-empty/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/question/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/question/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/propeller/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/propeller/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/product-top/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/product-top/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/product-starred/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/product-starred/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/product-no-ads/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/product-no-ads/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/product-nabolagsprofil/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/product-nabolagsprofil/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/product-highlight-listing/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/product-highlight-listing/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/product-carousel/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/product-carousel/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/product-bump/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/product-bump/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/product-blink/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/product-blink/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/plus/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/plus/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/plots/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/plots/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/playhouse/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/playhouse/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/play/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/play/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/plane-ticket/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/plane-ticket/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/pin-round/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/pin-round/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/pin-marker/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/pin-marker/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/phone-used/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/phone-used/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/phone-scratched/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/phone-scratched/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/phone-new/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/phone-new/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/paw/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/paw/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/parking/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/parking/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/paint-roller/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/paint-roller/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/office-desk/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/office-desk/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/norwegian-motor/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/norwegian-motor/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/no-smoking/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/no-smoking/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/new-ad/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/new-ad/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/nettbil/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/nettbil/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/mountain/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/mountain/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/motorcycle/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/motorcycle/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/minus/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/minus/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/messages/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/messages/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/message/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/message/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/measure/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/measure/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/market/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/market/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/map/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/map/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/manual/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/manual/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/mailbox/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/mailbox/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/mail/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/mail/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/lock-shield/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/lock-shield/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/list-sort/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/list-sort/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/link-external/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/link-external/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/link/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/link/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/like/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/like/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/lift/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/lift/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/leaf/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/leaf/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/layers/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/layers/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/laundry/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/laundry/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/landscape/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/landscape/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/krone/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/krone/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/keys/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/keys/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/job/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/job/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/instagram/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/instagram/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/info/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/info/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/image/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/image/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/house-person/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/house-person/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/house-modern/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/house-modern/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/house-cabin/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/house-cabin/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/house-bed/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/house-bed/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/hotel/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/hotel/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/honk/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/honk/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/history/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/history/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/hiking/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/hiking/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/heart-rate/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/heart-rate/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/grill/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/grill/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/grid/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/grid/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/graph-pie/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/graph-pie/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/graph-line/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/graph-line/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/gas-hybrid/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/gas-hybrid/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/gas-fuel/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/gas-fuel/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/gas-diesel/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/gas-diesel/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/front-wheel-drive/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/front-wheel-drive/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/fitness/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/fitness/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/fishing/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/fishing/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/fireplace/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/fireplace/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/filter/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/filter/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/file/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/file/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/feedback/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/feedback/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/favorite/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/favorite/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/farm/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/farm/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/facebook/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/facebook/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/eye-on/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/eye-on/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/eye-off/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/eye-off/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/expand/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/expand/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/exchange/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/exchange/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/engine-belt/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/engine-belt/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/engine/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/engine/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/energy/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/energy/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/edit/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/edit/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/economy/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/economy/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/drink/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/drink/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/download/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/download/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/double-bed/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/double-bed/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/dots/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/dots/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/door/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/door/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/dislike/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/dislike/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/discount/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/discount/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/diner/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/diner/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/dating/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/dating/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/cursor/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/cursor/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/credit-card/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/credit-card/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/cottage-plot/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/cottage-plot/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/color-palette/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/color-palette/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/cog/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/cog/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/close/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/close/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/clock/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/clock/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/circle-user/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/circle-user/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/circle-plus/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/circle-plus/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/chevron-up/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/chevron-up/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/chevron-right/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/chevron-right/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/chevron-left/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/chevron-left/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/chevron-down/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/chevron-down/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/chevron-double-right/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/chevron-double-right/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/chevron-double-left/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/chevron-double-left/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/checklist/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/checklist/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/check/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/check/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/chat-support/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/chat-support/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/chat-request/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/chat-request/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/charter/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/charter/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/charger/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/charger/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/chainsaw/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/chainsaw/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/cart/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/cart/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/car-subscription/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/car-subscription/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/car-service/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/car-service/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/car-rent/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/car-rent/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/car-key/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/car-key/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/car/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/car/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/camping/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/camping/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/camera/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/camera/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/calendar/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/calendar/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/calculator/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/calculator/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/cabin-hut/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/cabin-hut/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/cabin/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/cabin/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/bus/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/bus/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/burger/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/burger/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/bulldozer/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/bulldozer/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/bulb/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/bulb/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/building-plot/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/building-plot/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/building/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/building/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/bookmark/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/bookmark/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/bolt/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/bolt/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/boat-length/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/boat-length/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/block/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/block/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/bin/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/bin/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/bell/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/bell/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/beach/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/beach/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/battery-half-full/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/battery-half-full/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/battery-full/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/battery-full/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/battery-empty/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/battery-empty/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/bank-ident/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/bank-ident/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/bank-id/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/bank-id/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/bank/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/bank/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/bag/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/bag/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/back-wheel-drive/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/back-wheel-drive/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/automatic/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/automatic/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/attachment/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/attachment/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/archway/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/archway/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/all-wheel-drive/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/all-wheel-drive/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/alert-warning/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/alert-warning/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/alert-success/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/alert-success/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/alert-info/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/alert-info/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/alert-error/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/alert-error/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/alert/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/alert/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/airplane-hotel/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/airplane-hotel/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/airplane/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/airplane/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/air-con/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/air-con/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/ads/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/ads/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/src/raw/active-ads/locales/en/messages.po",
+      "dest": "/icons/**/%original_file_name%",
+      "translation": "/src/raw/active-ads/locales/%two_letters_code%/messages.po",
+    },
+  ]


### PR DESCRIPTION
A quick fix to make the failed CI job pass:
https://github.com/warp-ds/icons/actions/runs/6810631933/job/18519298706