### PR TITLE
fix: Add export to react script which broke exports in index.js

### DIFF
--- a/scripts/output/react.js
+++ b/scripts/output/react.js
@@ -27,7 +27,7 @@ getSVGs().forEach(({ svg, filename, exportName, name }) => {
     `import { activateI18n } from '../src/utils/i18n';`,
     `activateI18n(enMessages, nbMessages, fiMessages);`,
     `const title = i18n.t({ message: \`${message}\`, id: '${id}', comment: '${comment}' });`,
-    `const ${exportName} = (attrs) => React.createElement('svg', { ${attrs.join(", ")}, dangerouslySetInnerHTML: { __html: ${'`'}${titleHtml}${svg.html}${'`'} }, ...attrs, });`,
+    `export const ${exportName} = (attrs) => React.createElement('svg', { ${attrs.join(", ")}, dangerouslySetInnerHTML: { __html: ${'`'}${titleHtml}${svg.html}${'`'} }, ...attrs, });`,
     `export default ${exportName};`
   ].join("\n");
 


### PR DESCRIPTION
When I removed the export from this script, I didn't realize the `index.js` which exports all icons would be broken. This fixes just that in case someone wants to import all the icons.