### PR TITLE
chore(crowdin-sync.yml): enable manual trigger of the workflow

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -8,6 +8,7 @@ on:
     # on weekdays is a proposed starting point. You may change the minute counter to
     # avoid crashing with other workflows.
     - cron: "0 8-17/2 * * 1-5" # At minute 0 past every 2nd hour from 8 through 17 on every day-of-week from Monday through Friday (https://crontab.guru/#0_8-17/2_*_*_1-5)
+  workflow_dispatch:
 
 jobs:
   synchronize-with-crowdin:


### PR DESCRIPTION
This PR sets `workflow_dispatch` event trigger to enable crowdin-sync workflow to be triggered manually. This will be useful when testing changes to the workflow in https://github.com/warp-ds/reusable-workflows

Here's an instruction how to manually run a workflow when this event trigger is set: https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow