### PR TITLE
chore(crowdin-sync): add PR comments feature

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -9,6 +9,7 @@ on:
     # avoid crashing with other workflows.
     - cron: "0 8-17/2 * * 1-5" # At minute 0 past every 2nd hour from 8 through 17 on every day-of-week from Monday through Friday (https://crontab.guru/#0_8-17/2_*_*_1-5)
   workflow_dispatch:
+  pull_request_review_comment:
 
 jobs:
   synchronize-with-crowdin:


### PR DESCRIPTION
If we comment on a text file configured with Crowdin in a Pull request, a notification with the comment is sent to the translator in Crowdin. 

Looks like this in Crowdin:
![image](https://media.github.schibsted.io/user/7008/files/c939210e-f230-43d6-948c-d38e0b9778d2)

**Note:** This feature is limited to PRs from Crowdin, so the translators will only be notified if we comment in a PR created by Crowdin.