### PR TITLE
fix: update strings for logout, picture-stack and organize

### DIFF
--- a/default-icon-descriptions.js
+++ b/default-icon-descriptions.js
@@ -1355,7 +1355,7 @@ export default {
     comment: "Title for login icon"
   },
   logout: {
-    message: "Logout",
+    message: "Exit door",
     id: "icon.title.logout",
     comment: "Title for logout icon"
   },

--- a/src/raw/logout/locales/en/messages.po
+++ b/src/raw/logout/locales/en/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-01-29 08:19+0100\n"
+"POT-Creation-Date: 2024-01-31 12:13+0100\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/logout.js:2
 msgid "icon.title.logout"
-msgstr "icon.title.logout"
+msgstr "Exit door"

--- a/src/raw/logout/locales/fi/messages.po
+++ b/src/raw/logout/locales/fi/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-01-29 08:19+0100\n"
+"POT-Creation-Date: 2024-01-31 12:13+0100\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/src/raw/logout/locales/nb/messages.po
+++ b/src/raw/logout/locales/nb/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-01-29 08:19+0100\n"
+"POT-Creation-Date: 2024-01-31 12:13+0100\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/src/raw/organize/locales/en/messages.po
+++ b/src/raw/organize/locales/en/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-01-29 08:19+0100\n"
+"POT-Creation-Date: 2024-01-31 12:11+0100\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/organize.js:2
 msgid "icon.title.organize"
-msgstr "icon.title.organize"
+msgstr "Two horizontal lines between two opposite vertical arrows"

--- a/src/raw/organize/locales/fi/messages.po
+++ b/src/raw/organize/locales/fi/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-01-29 08:19+0100\n"
+"POT-Creation-Date: 2024-01-31 12:11+0100\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/src/raw/organize/locales/nb/messages.po
+++ b/src/raw/organize/locales/nb/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-01-29 08:19+0100\n"
+"POT-Creation-Date: 2024-01-31 12:11+0100\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/src/raw/picture-stack/icon_16.svg
+++ b/src/raw/picture-stack/icon_16.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16">
+  <path stroke="#3F3F46" stroke-linecap="round" stroke-linejoin="round"
+    d="M12.153.667H1.18a.504.504 0 0 0-.513.493v11.013c0 .273.23.494.513.494h10.973c.284 0 .513-.221.513-.494V1.16a.504.504 0 0 0-.513-.493Z" />
+  <path stroke="#3F3F46" stroke-linecap="round" stroke-linejoin="round"
+    d="M2.667 15.333H14.7c.168 0 .329-.06.448-.168a.55.55 0 0 0 .185-.407V2.706" />
+  <path stroke="#3F3F46" stroke-linecap="round" stroke-linejoin="round"
+    d="M4.667 12.667 8.434 7.76a1 1 0 0 1 1.572-.085l2.64 3.301M4.667 3.333a1.333 1.333 0 1 1 0 2.667 1.333 1.333 0 0 1 0-2.667Z" />
+</svg>

--- a/src/raw/picture-stack/locales/en/messages.po
+++ b/src/raw/picture-stack/locales/en/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-01-29 08:19+0100\n"
+"POT-Creation-Date: 2024-01-31 12:11+0100\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: scripts/temp/picture-stack.js:2
 msgid "icon.title.picture-stack"
-msgstr "icon.title.picture-stack"
+msgstr "Picture stack"

--- a/src/raw/picture-stack/locales/fi/messages.po
+++ b/src/raw/picture-stack/locales/fi/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-01-29 08:19+0100\n"
+"POT-Creation-Date: 2024-01-31 12:11+0100\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/src/raw/picture-stack/locales/nb/messages.po
+++ b/src/raw/picture-stack/locales/nb/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2024-01-29 08:19+0100\n"
+"POT-Creation-Date: 2024-01-31 12:11+0100\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"


### PR DESCRIPTION
Fixes [WARP-486](https://nmp-jira.atlassian.net/browse/WARP-486)

Update message strings in PictureStack, Organize and Logout icons after notification from the translation team.

Not sure what happened but the messages were fixed by removing the `locales` folders and running `pnpm i18n` command again.