### PR TITLE
fix: use correct color in users icon

### DIFF
--- a/src/raw/users/icon_16.svg
+++ b/src/raw/users/icon_16.svg
@@ -1,3 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16">
-<path stroke="#47474F" stroke-linecap="round" stroke-linejoin="round" d="M5 8a2.75 2.75 0 1 0 0-5.5A2.75 2.75 0 0 0 5 8ZM.5 13.5a4.5 4.5 0 0 1 9-.024M11.818 9a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5ZM10.543 10.045A3.684 3.684 0 0 1 15.5 13.48"/>
+  <path stroke="#3F3F46" stroke-linecap="round" stroke-linejoin="round"
+    d="M5 8a2.75 2.75 0 1 0 0-5.5A2.75 2.75 0 0 0 5 8ZM.5 13.5a4.5 4.5 0 0 1 9-.024M11.818 9a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5ZM10.543 10.045A3.684 3.684 0 0 1 15.5 13.48" />
 </svg>

--- a/src/raw/users/icon_24.svg
+++ b/src/raw/users/icon_24.svg
@@ -1,3 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
-<path stroke="#47474F" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7.5 12a4.125 4.125 0 1 0 0-8.25 4.125 4.125 0 0 0 0 8.25ZM.75 20.25a6.75 6.75 0 0 1 13.5-.035M17.727 13.5a3.375 3.375 0 1 0 0-6.75 3.375 3.375 0 0 0 0 6.75ZM15.813 15.068a5.525 5.525 0 0 1 7.437 5.15"/>
+  <path stroke="#3F3F46" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+    d="M7.5 12a4.125 4.125 0 1 0 0-8.25 4.125 4.125 0 0 0 0 8.25ZM.75 20.25a6.75 6.75 0 0 1 13.5-.035M17.727 13.5a3.375 3.375 0 1 0 0-6.75 3.375 3.375 0 0 0 0 6.75ZM15.813 15.068a5.525 5.525 0 0 1 7.437 5.15" />
 </svg>

--- a/src/raw/users/icon_32.svg
+++ b/src/raw/users/icon_32.svg
@@ -1,3 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="none" viewBox="0 0 32 32">
-<path stroke="#47474F" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 16a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11ZM1 27a9 9 0 0 1 18-.047M23.635 18a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9ZM21.084 20.09A7.368 7.368 0 0 1 31 26.96"/>
+  <path stroke="#3F3F46" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+    d="M10 16a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11ZM1 27a9 9 0 0 1 18-.047M23.635 18a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9ZM21.084 20.09A7.368 7.368 0 0 1 31 26.96" />
 </svg>


### PR DESCRIPTION
The previously applied hex was incorrect, also according to what is in Figma. This change will make sure User icon's `stroke` will change to `currentColor` upon build.