### PR TITLE
fix: Adjust which hex values to be replaced with 'currentColor'

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -13,7 +13,7 @@ const SRC_DIR = path.join(basedir, "src/raw");
 const DIST_DIR = path.join(basedir, "dist/icons");
 
 // these are the only colors we will replace to currentColor
-const magicColors = ['#3f3f46', '#9ba8ba', '#71717a', '#767676', '#0063fb', '#d91f0a', '#d5840b', '#059e6f', '#0386bf', '#6f7d90'].map(v => v.toLowerCase())
+const magicColors = ['#47474f', '#3f3f46', '#9ba8ba', '#71717a'].map(v => v.toLowerCase())
 const colorProps = [
   'color',
   'fill',


### PR DESCRIPTION
- Added current hex value for semantic icon default token
- Removed hex values that are no longer present in any of the raw icons
